### PR TITLE
Refill the tray at the end of a player turn. Add a refill method to T…

### DIFF
--- a/src/entities/game_state.py
+++ b/src/entities/game_state.py
@@ -22,13 +22,20 @@ class GameState:
         '''Returns the current player'''
         return self.game_turn % self.num_players
 
-    def end_player_turn(self, player):
+    def end_player_turn(self, player, tray, bird_deck):
         '''
         Ends the given player's turn.
 
         Args:
             player (Player): The player whose turn is ending.
+            tray (Tray): The bird tray, which should be full at the end of a turn.
+            bird_deck (Deck): The bird deck from which the tray is refilled.
         '''
+        # check if the tray needs to be refilled
+        if tray.is_not_full():
+            tray.refill(bird_deck)
+        
+        # manage turn accounting
         player.end_turn()
         self.game_turn += 1
 

--- a/src/entities/tray.py
+++ b/src/entities/tray.py
@@ -22,40 +22,53 @@ class Tray:
         '''
         Draw a bird from the tray.
         
-        :param common_name: The common name of the bird to draw.
-        :type common_name: str
+        Args:
+            common_name (str): The common name of the bird to draw.
         '''
 
         if common_name not in self.birds:
             raise ValueError(f"{common_name} does not exist in the tray.")
         return self.birds.pop(common_name)
-    
-    def flush(self, discard_pile, bird_deck):
-        '''
-        Flush the tray and add all birds to the discard pile.
-        Refill the tray with birds from the deck.
-        
-        :param dicsard_pile: The discard pile.
-        :type deck: Deck
-        :param bird_deck: The bird deck
-        :type deck: Deck
-        '''
-
-        while len(self.birds) > 0:
-            discard_pile.add_card(self.birds.popitem()[1])
-        
-        while len(self.birds) < 3 and bird_deck.get_count() > 0:
-            bird = bird_deck.draw_card()
-            self.add_bird(bird)
 
     def add_bird(self, bird):
         '''
         Add a bird to the tray.
         
-        :param bird: The bird to add.
-        :type bird: Bird
+        Args:
+            bird (Bird): The bird to add.
         '''
         self.birds[bird.get_name()] = bird
+
+    def is_not_full(self):
+        '''Public method that returns True if the tray is not full, False otherwise.'''
+        return self.get_count() < self.capacity
+    
+    def refill(self, bird_deck):
+        '''
+        Refill the tray with birds from the deck.
+        
+        Args:
+            bird_deck (Deck): The bird deck.
+        '''
+
+        while self.is_not_full() and bird_deck.get_count() > 0:
+            bird = bird_deck.draw_card()
+            self.add_bird(bird)
+
+    def flush(self, discard_pile, bird_deck):
+        '''
+        Flush the tray and add all birds to the discard pile.
+        Refill the tray with birds from the deck.
+        
+        Args:
+            discard_pile (Deck): The discard pile.
+            bird_deck (Deck): The bird deck.
+        '''
+
+        while len(self.birds) > 0:
+            discard_pile.add_card(self.birds.popitem()[1])
+        
+        self.refill(bird_deck)
 
     def render(self):
         '''Render the tray.'''

--- a/tests/entities/test_game_state.py
+++ b/tests/entities/test_game_state.py
@@ -3,6 +3,9 @@ from src.entities.game_state import GameState
 from src.entities.player import Player
 from src.entities.hand import BirdHand
 from src.entities.food_supply import FoodSupply
+from src.entities.deck import Deck
+from src.entities.tray import Tray
+from unittest.mock import patch
 
 class TestGameState(unittest.TestCase):
     def setUp(self):
@@ -10,33 +13,39 @@ class TestGameState(unittest.TestCase):
         self.num_players = 4
         self.game_state = GameState(num_turns=self.num_turns, num_players=self.num_players)  # Example initialization with 10 turns and 4 players
         self.test_player = Player(name="Test Player", bird_hand=BirdHand(), food_supply=FoodSupply(), num_turns=self.num_turns)
+        self.bird_deck = Deck()
+        self.tray = Tray()
 
     def test_get_num_turns(self):
         self.assertEqual(self.game_state.get_num_turns(), self.num_turns)
 
     def test_num_turns_does_not_change(self):
-        self.game_state.end_player_turn(self.test_player)
+        self.game_state.end_player_turn(self.test_player, self.tray, self.bird_deck)
         self.assertEqual(self.game_state.get_num_turns(), self.num_turns)
 
     def test_get_current_player(self):
         self.assertEqual(self.game_state.get_current_player(), 0)  # Assuming player indexing starts from 0
 
     def test_end_player_turn(self):
-        self.game_state.end_player_turn(player=self.test_player)
+        with patch('src.entities.tray.Tray.refill') as mock_refill:
+            self.game_state.end_player_turn(player=self.test_player, tray=self.tray, bird_deck=self.bird_deck)
 
-        # game turn increments
-        self.assertEqual(self.game_state.game_turn, 1)
+            # tray is empty, check that tray.refill() is called
+            mock_refill.assert_called_once_with(self.bird_deck)
 
-        # current player changes
-        self.assertEqual(self.game_state.get_current_player(), 1)
+            # game turn increments
+            self.assertEqual(self.game_state.game_turn, 1)
 
-        # player's turns remaining decrements
-        self.assertEqual(self.test_player.get_turns_remaining(), self.num_turns - 1)
+            # current player changes
+            self.assertEqual(self.game_state.get_current_player(), 1)
+
+            # player's turns remaining decrements
+            self.assertEqual(self.test_player.get_turns_remaining(), self.num_turns - 1)
 
     def test_is_game_over(self):
         self.assertFalse(self.game_state.is_game_over())
         for _ in range(self.num_players * self.num_turns):
-            self.game_state.end_player_turn(self.test_player)
+            self.game_state.end_player_turn(player=self.test_player, tray=self.tray, bird_deck=self.bird_deck)
         self.assertTrue(self.game_state.is_game_over())
 
 if __name__ == '__main__':

--- a/tests/entities/test_tray.py
+++ b/tests/entities/test_tray.py
@@ -13,6 +13,7 @@ class TestTray(unittest.TestCase):
             Bird("Cardinal", 3, 1),
             Bird("Barn Swallow", 3, 1)
         ]
+        self.bird_deck = Deck()
 
     def test_get_count(self):
         # Test when the tray is empty
@@ -22,6 +23,15 @@ class TestTray(unittest.TestCase):
         for bird in self.birds:
             self.tray.add_bird(bird)
         self.assertEqual(self.tray.get_count(), 3)
+
+    def test_get_birds_in_tray(self):
+        # Test when the tray is empty
+        self.assertEqual(self.tray.get_birds_in_tray(), [])
+
+        # Test when the tray has birds
+        for bird in self.birds:
+            self.tray.add_bird(bird)
+        self.assertEqual(self.tray.get_birds_in_tray(), self.birds)
 
     def test_see_birds_in_tray(self):
         # Test when the tray is empty
@@ -38,6 +48,45 @@ class TestTray(unittest.TestCase):
         drawn_bird = self.tray.draw_bird(bird.get_name())
         self.assertEqual(drawn_bird, bird)
         self.assertEqual(self.tray.see_birds_in_tray(), [])
+
+    def test_add_bird(self):
+        bird = self.birds[0]
+        self.tray.add_bird(bird)
+        self.assertEqual(self.tray.see_birds_in_tray(), [bird.get_name()])
+
+    def test_is_not_full(self):
+        # Test when the tray is empty
+        self.assertTrue(self.tray.is_not_full())
+
+        # Test whe the tray is partially full
+        self.tray.add_bird(self.birds[0])
+        self.assertTrue(self.tray.is_not_full())
+
+        # Test when the tray is full
+        for bird in self.birds[1:]:
+            self.tray.add_bird(bird)
+        self.assertFalse(self.tray.is_not_full())
+
+    def test_refill_when_empty(self):
+        # Test when the tray is empty
+        for bird in self.birds:
+            self.bird_deck.add_card(bird)
+        self.tray.refill(self.bird_deck)
+        self.assertEqual(self.tray.see_birds_in_tray(), [bird.get_name() for bird in self.birds])
+
+    def test_refill_when_partially_full(self):
+        # Test when the tray is partially full
+        for bird in self.birds:
+            self.bird_deck.add_card(bird)
+        self.tray.add_bird(self.birds[0])
+        self.tray.refill(self.bird_deck)
+        self.assertEqual(self.tray.see_birds_in_tray(), [bird.get_name() for bird in self.birds])
+
+    def test_refill_when_deck_is_empty(self):
+        # Test when the tray is partially full and the deck is empty
+        self.tray.add_bird(self.birds[0])
+        self.tray.refill(self.bird_deck)
+        self.assertEqual(self.tray.see_birds_in_tray(), [self.birds[0].get_name()])
 
     def test_flush(self):
         # Test when the deck is empty


### PR DESCRIPTION
…ray. Add a is_not_full method to Tray for use when checking if the tray can be refilled. Add a call to tray.refill in GameState.end_player_turn, which now requires passing of the tray and bird deck.