### PR TITLE
Update README and CLAUDE.md for current project state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,44 +13,45 @@ wingspan/
 │   ├── constants.py      # Game phase constants
 │   ├── entities/         # Core game components (bird, deck, player, board, etc.)
 │   ├── rl/
-│   │   ├── policy.py     # Policy ABC, RandomPolicy, MCTSPolicy (stubs)
+│   │   ├── policy.py     # Policy ABC, RandomPolicy, MCTSPolicy
 │   │   └── mcts.py       # Node, Edge classes for game tree
 │   ├── utilities/
-│   │   ├── utils.py      # Rendering helpers
+│   │   ├── utils.py      # Terminal rendering helpers
 │   │   └── player_factory.py  # Player creation (avoids circular imports)
-│   └── game.py           # Main game loop orchestration
-├── tests/                # unittest-based test suite (134 tests)
+│   └── game.py           # Game setup, turn loop, CLI entry point
+├── tests/                # 157 unit tests (unittest + pytest)
 ├── data/                 # Bird data: 180 species from CSV, generated into bird_list.py
 └── __init__.py
 ```
 
 ## Running
 ```bash
-# Sync dependencies (creates .venv)
 uv sync
 
 # Run tests
 uv run python -m pytest
 
-# Run a game (from repo root)
-uv run python -m src.game                           # default: 2 bots, 10 turns each
-uv run python -m src.game --num_players 2 --num_human 1      # 2 players, 1 human
+# Play against random bot
+uv run python -m src.game --num_players 2 --num_human 1
+
+# Play against MCTS bot
+uv run python -m src.game --num_players 2 --num_human 1 --policy mcts
+
+# Stronger MCTS (more simulations, slower)
+uv run python -m src.game --num_players 2 --num_human 1 --policy mcts --num_simulations 500
 ```
 
 ## Architecture Notes
 - **GameState** consolidates all game objects: bird_deck, discard_pile, tray, bird_feeder, players, phase
-- **MCTSGameState** extends GameState with `to_representation()`/`from_representation()` for hashable state serialization
-- **Players**: `HumanPlayer` (CLI input) and `BotPlayer` (policy-driven) inherit from `Player`
-- **Policies**: `Policy.__call__(state, actions) → str`. `RandomPolicy` picks uniformly. `MCTSPolicy` has rhoUCT scaffold (expand/playout/backpropagate are stubs)
-- **Actions**: 3 of 4 actions implemented: play_a_bird, gain_food, draw_a_bird. Lay eggs NOT implemented
-- **Simplifications**: Birds only have VP and food cost (no habitats, egg capacity, or special powers). Food is a single token type (real game has 5 types). No bonus cards, no end-of-round goals
+- **MCTSGameState** extends GameState with `to_representation()`/`from_representation()` for hashable state serialization (determinizes hidden info for imperfect-information MCTS)
+- **Players**: `HumanPlayer` (CLI) and `BotPlayer` (policy-driven) inherit from `Player`
+- **Policies**: `Policy.__call__(state, actions) → str`. `RandomPolicy` picks uniformly. `MCTSPolicy` runs full select → expand → playout → backpropagate loop with UCB1 tree policy
+- **Actions**: 3 of 4 implemented: play_a_bird, gain_food, draw_a_bird. Lay eggs NOT implemented
+- **Simplifications**: Birds only have VP and food cost (no habitats, egg capacity, or powers). Single food type. No bonus cards or end-of-round goals
 - **Entity serialization**: All entities have `to_representation()` returning hashable types; BirdHand, GameBoard, Tray have `from_representation()` for reconstruction
 
-## MCTS Development Frontier
-The `MCTSPolicy._expand()`, `._playout()`, and `._backpropagate()` methods are stubs. These are the next pieces to implement. Key design decisions (from issue #47):
-- Expectimax tree: decision nodes (player choices) and chance nodes (stochastic outcomes)
-- Handle stochasticity via simulation, not enumeration
-- rhoUCT = UCT + environment model
+## Next Milestone
+Self-play training framework (#74): run bot-vs-bot games, collect experience, train policies, persist for reuse. Then learned playout policy (#73) and value network (#75).
 
 ## Conventions
 - Python unittest framework, run with pytest
@@ -59,3 +60,4 @@ The `MCTSPolicy._expand()`, `._playout()`, and `._backpropagate()` methods are s
 - Ruff for linting (E/F/I/UP rules) and formatting (line-length 120)
 - Pre-commit hooks run ruff on commit; CI runs lint + tests on push/PR to main
 - Test files mirror source structure in tests/ directory
+- Internal methods prefixed with `_`; public API is the unprefixed methods

--- a/README.md
+++ b/README.md
@@ -5,8 +5,33 @@ Reinforcement learning agents for the board game [Wingspan](https://stonemaierga
 ## Strategy
 
 1. **Game engine** — Implement a playable simplified Wingspan (done)
-2. **MCTS agent** — Monte Carlo Tree Search with UCT to learn action-value distributions (in progress)
-3. **Self-play training** — Agents play against each other to iteratively improve their policies (future)
+2. **MCTS agent** — Monte Carlo Tree Search with UCT to select actions (done)
+3. **Self-play training** — Agents play against each other to iteratively improve their policies (next)
+
+## Playing the Game
+
+```bash
+# Install uv if you don't have it
+# https://docs.astral.sh/uv/getting-started/installation/
+
+# Sync dependencies (creates .venv automatically)
+uv sync
+
+# Play against a random bot
+uv run python -m src.game --num_players 2 --num_human 1
+
+# Play against an MCTS bot (smarter, ~0.2s per decision)
+uv run python -m src.game --num_players 2 --num_human 1 --policy mcts
+
+# Crank up MCTS simulations for stronger play
+uv run python -m src.game --num_players 2 --num_human 1 --policy mcts --num_simulations 500
+
+# Watch two bots play each other
+uv run python -m src.game
+
+# Run tests
+uv run python -m pytest
+```
 
 ## Game Simplifications
 
@@ -28,74 +53,55 @@ These simplifications reduce the state space to make MCTS tractable while preser
 ```
 wingspan/
 ├── src/
+│   ├── constants.py        # Game phase constants
 │   ├── entities/           # Core game objects
 │   │   ├── bird.py         # Bird card (name, VP, food cost)
 │   │   ├── birdfeeder.py   # Shared food supply (5 tokens, auto-reroll)
 │   │   ├── deck.py         # Draw pile with shuffle
 │   │   ├── food_supply.py  # Per-player food tokens
 │   │   ├── gameboard.py    # Per-player board (5 bird slots)
-│   │   ├── game_state.py   # Turn tracking, player rotation, game-over logic
+│   │   ├── game_state.py   # GameState + MCTSGameState (serialization)
 │   │   ├── hand.py         # Player hand management
-│   │   ├── player.py       # HumanPlayer (CLI) and BotPlayer (policy-driven)
+│   │   ├── player.py       # Player, HumanPlayer (CLI), BotPlayer (policy-driven)
 │   │   └── tray.py         # Face-up bird display (3 slots)
 │   ├── rl/
-│   │   └── reinforcement_learning.py  # Policy ABC, RandomPolicy, State
+│   │   ├── policy.py       # Policy ABC, RandomPolicy, MCTSPolicy
+│   │   └── mcts.py         # Node and Edge classes for game tree
 │   ├── utilities/
-│   │   └── utils.py        # Tabular rendering
-│   └── game.py             # Game setup and play loop
-├── tests/                  # 80+ unit tests (unittest + pytest)
+│   │   ├── utils.py        # Terminal rendering helpers
+│   │   └── player_factory.py  # Player creation (avoids circular imports)
+│   └── game.py             # Game setup, turn loop, CLI entry point
+├── tests/                  # 157 unit tests (unittest + pytest)
 ├── data/
 │   ├── bird_data.csv       # Source bird data
 │   ├── bird_list.py        # Generated: 180 Bird objects
 │   └── generate_bird_list.py
 ```
 
-## Getting Started
-
-```bash
-# Install uv if you don't have it
-# https://docs.astral.sh/uv/getting-started/installation/
-
-# Sync dependencies (creates .venv automatically)
-uv sync
-
-# Run tests
-uv run python -m pytest
-
-# Play a game (2 bots, 10 turns each)
-uv run python -m src.game
-
-# Play with a human player (2 players, 1 human)
-uv run python -m src.game --num_players 2 --num_human 1
-```
-
 ## Architecture
 
 ### Game Engine
-- **Players** inherit from a base `Player` class. `HumanPlayer` takes CLI input; `BotPlayer` delegates decisions to a `Policy` object
+- **GameState** consolidates all game objects: bird deck, discard pile, tray, bird feeder, players, and turn/phase tracking
+- **Players** inherit from `Player`. `HumanPlayer` takes CLI input; `BotPlayer` delegates decisions to a `Policy` object
 - **Game loop** rotates through players, validates legal actions, executes the chosen action, and updates state until turns are exhausted
 - **Scoring** sums victory points of birds on each player's board
 
-### RL Components
-- **Policy** (ABC) maps game states to action probability distributions, with phase-specific methods for each decision point
-- **RandomPolicy** provides a uniform random baseline
-- **State** wraps the game state for policy consumption, tracking the current decision phase
+### RL / MCTS
+- **Policy** maps `(state, actions) → chosen action`. `RandomPolicy` picks uniformly; `MCTSPolicy` uses tree search
+- **MCTSPolicy** implements the full select → expand → playout → backpropagate loop:
+  - **Select**: traverse the tree via UCB1 to find a leaf node
+  - **Expand**: generate child nodes for each legal action (using `copy.deepcopy`)
+  - **Playout**: simulate the game to completion using `RandomPolicy` (cloned via `MCTSGameState.from_representation` for imperfect-information determinization)
+  - **Backpropagate**: walk parent pointers updating visit counts and rewards
+- **MCTSGameState** extends GameState with hashable `to_representation()` / `from_representation()` for state serialization, handling hidden information (opponent hands stored as counts)
 
-### MCTS (in progress, branch `47-implement-basic-mcts`)
-- **MCTSGameState** subclass with hashable `to_representation()` / `from_representation()` for game tree nodes
-- **Expectimax** tree structure: decision nodes (player choices) and chance nodes (stochastic outcomes)
-- **rhoUCT** outline for balancing exploration/exploitation with a stochastic environment model
-- 26 commits ahead of main with state representation, player factory, and policy refactoring
+## Roadmap
 
-## Open Issues
+See [GitHub Issues](https://github.com/keithgw/wingspan/issues) for the full backlog. Next milestones:
 
-See [GitHub Issues](https://github.com/keithgw/wingspan/issues) for the full backlog. Key items:
-
-- **#47** — Implement basic MCTS (core next milestone)
-- **#53** — Refactor play loop for mid-turn simulation
-- **#65** — Simplify Policy interface (remove phase dependency)
-- **#55, #57, #58** — Improve state model with card memory
-- **#19** — Turn zero draft decisions
+- **#74** — Self-play training framework with policy persistence
+- **#73** — Replace random playout policy with a learned policy
+- **#75** — Add a value network to evaluate positions without full playout
 
 ## References
 


### PR DESCRIPTION
## Summary
Both docs were stale (referenced old branch, old file structure, listed completed issues as open, described MCTS stubs as "in progress"). Updated to reflect today's work:

- **Strategy**: MCTS is done, self-play training is next
- **Playing the Game**: Added `--policy mcts` and `--num_simulations` examples
- **Project Structure**: Updated file tree (policy.py, mcts.py, constants.py, player_factory.py)
- **Architecture**: Describes the working MCTS loop (select/expand/playout/backpropagate)
- **Roadmap**: Points to issues #74, #73, #75 instead of listing closed issues
- **CLAUDE.md**: Updated test count (157), removed "stubs" language, added CLI examples

## Test plan
- [x] No code changes, only documentation
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)