### PR TITLE
Rewrite report as self-contained HTML, add v3 baseline

### DIFF
--- a/docs/model_changelog.md
+++ b/docs/model_changelog.md
@@ -6,6 +6,46 @@ Evaluation protocol: 50 games alternating first/second player, opponent is `Rand
 
 ---
 
+## v3 — Interaction + Polynomial Features
+
+**Date:** 2026-03-30
+**Git ref:** main (post-PR #96, #98)
+**Baseline file:** `models/baselines/v3_linear_26features.npz`
+
+### Features (26 state + 8 option)
+
+Added 4 interaction/polynomial features from #92 that encode non-linear relationships the linear model cannot learn from raw features alone:
+
+- `food_gap_for_best` — how much food needed to play the most expensive bird in hand
+- `vp_at_stake` — VP gap between best bird in hand and best affordable bird (opportunity cost)
+- `endgame_flag` — binary flag when 3 or fewer turns remain
+- `urgency` — score gap to close divided by turns remaining
+
+### Training
+
+| Parameter | Value |
+|-----------|-------|
+| Iterations | 20,000 |
+| Games/iteration | 100 |
+| Learning rate | 0.01 |
+| Turns/game | 10 |
+| Workers | 14 (parallel, #95) |
+
+### Evaluation vs Random
+
+| Metric | Value |
+|--------|-------|
+| Win rate | 84.7% |
+| Mean score | 14.0 |
+| Mean opponent score | 8.4 |
+| Mean score diff | +5.6 |
+
+### Notes
+
+Modest improvement over v2 (+1.1% win rate, +0.2 score diff). The new features ranked highly by importance: `urgency` was #1 overall, `endgame_flag` #5, `vp_at_stake` #8. The model learned intuitive strategies: play aggressively when behind (`urgency`), shift to playing birds in endgame (`endgame_flag`), gain food when holding expensive unaffordable birds (`vp_at_stake`). First model trained with parallel self-play (#95), reducing wall-clock training time ~7x.
+
+---
+
 ## v2 — Strategic + Deck Composition Features
 
 **Date:** 2026-03-30

--- a/src/rl/interpreter.py
+++ b/src/rl/interpreter.py
@@ -478,9 +478,19 @@ def load_checkpoint_weights(models_dir, max_checkpoints=50):
 
     for iteration, filepath in entries:
         policy = LinearPolicy.load(filepath)
+        # Skip checkpoints with mismatched feature dimensions (e.g. old runs)
+        if policy.weights.shape[0] != NUM_FEATURES:
+            continue
         iterations.append(iteration)
         action_weights_list.append(policy.weights)
         sub_weights_list.append(policy.sub_weights)
+
+    if not iterations:
+        return {
+            "iterations": [],
+            "action_weights": np.empty((0, NUM_FEATURES, 3)),
+            "sub_weights": np.empty((0, NUM_SUB_FEATURES)),
+        }
 
     return {
         "iterations": iterations,

--- a/src/rl/report.py
+++ b/src/rl/report.py
@@ -1,374 +1,354 @@
-"""Generate analysis report notebooks for trained policies."""
+"""Generate self-contained HTML analysis reports for trained policies."""
 
-import json
+import base64
+import io
 import os
+from datetime import date
 
 
-def _md_cell(source):
-    """Create a markdown notebook cell."""
-    return {"cell_type": "markdown", "metadata": {}, "source": _lines(source)}
+def _fig_to_base64(fig):
+    """Render a matplotlib figure to a base64-encoded PNG data URI."""
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=150, bbox_inches="tight")
+    buf.seek(0)
+    encoded = base64.b64encode(buf.read()).decode("utf-8")
+    import matplotlib.pyplot as plt
+
+    plt.close(fig)
+    return f"data:image/png;base64,{encoded}"
 
 
-def _code_cell(source, hidden=False):
-    """Create a code notebook cell."""
-    cell = {"cell_type": "code", "metadata": {}, "source": _lines(source), "outputs": [], "execution_count": None}
-    if hidden:
-        cell["metadata"]["jupyter"] = {"source_hidden": True}
-    return cell
-
-
-def _lines(text):
-    """Split text into notebook-format line list (each line ends with \\n except last)."""
-    lines = text.strip().split("\n")
-    return [line + "\n" for line in lines[:-1]] + [lines[-1]]
+def _html_table(headers, rows, align=None):
+    """Build an HTML table string."""
+    parts = ['<table class="report-table">', "<thead><tr>"]
+    for i, h in enumerate(headers):
+        a = align[i] if align else "left"
+        parts.append(f'<th style="text-align:{a}">{h}</th>')
+    parts.append("</tr></thead><tbody>")
+    for row in rows:
+        parts.append("<tr>")
+        for i, val in enumerate(row):
+            a = align[i] if align else "left"
+            parts.append(f'<td style="text-align:{a}">{val}</td>')
+        parts.append("</tr>")
+    parts.append("</tbody></table>")
+    return "\n".join(parts)
 
 
 def generate_report(policy_path, output_path=None, models_dir="models"):
-    """Generate a Jupyter notebook analyzing a trained policy.
+    """Generate a self-contained HTML report analyzing a trained policy.
 
     Args:
         policy_path: Path to a .npz policy file.
-        output_path: Where to write the .ipynb (default: alongside policy).
+        output_path: Where to write the .html (default: alongside policy).
         models_dir: Directory with checkpoints for evolution analysis.
 
     Returns:
-        Path to the generated notebook.
+        Path to the generated report.
     """
     if not os.path.isfile(policy_path):
         raise FileNotFoundError(f"Policy file not found: {policy_path}")
 
     if output_path is None:
-        output_path = os.path.join(os.path.dirname(policy_path) or ".", "policy_report.ipynb")
+        output_path = os.path.join(os.path.dirname(policy_path) or ".", "policy_report.html")
 
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
-    # Use repr() for safe embedding of paths in generated Python code
-    safe_policy_path = repr(policy_path)
-    safe_models_dir = repr(models_dir)
+    import matplotlib.pyplot as plt
+    import seaborn as sns
 
-    cells = []
-
-    # --- Title and setup ---
-    cells.append(
-        _md_cell(f"""# Policy Analysis Report
-
-Generated from `{policy_path}`.
-
-This notebook provides a comprehensive analysis of the trained policy:
-1. **Weight inspection** — What features drive each action?
-2. **Feature importance** — Which features matter most?
-3. **Strategy rules** — Human-readable summary of learned behavior
-4. **Decision traces** — Step-by-step scoring for sample game states
-5. **Weight evolution** — How weights changed during training
-
-Run all cells to regenerate, or modify and explore interactively.""")
+    from src.rl.featurizer import ACTION_INDEX, FEATURE_NAMES, OPTION_FEATURE_NAMES
+    from src.rl.interpreter import (
+        compute_feature_importance,
+        compute_weight_evolution,
+        format_game_context,
+        generate_diverse_states,
+        generate_strategy_rules,
+        get_sub_decision_options,
+        load_checkpoint_weights,
+        trace_action_decision,
+        trace_sub_decision,
     )
+    from src.rl.linear_policy import LinearPolicy
 
-    cells.append(
-        _code_cell(
-            f"""import numpy as np
-import matplotlib.pyplot as plt
-import seaborn as sns
-
-from src.rl.linear_policy import LinearPolicy
-from src.rl.featurizer import FEATURE_NAMES, OPTION_FEATURE_NAMES, ACTION_INDEX
-from src.rl.interpreter import (
-    compute_feature_importance,
-    compute_sub_feature_importance,
-    generate_strategy_rules,
-    format_strategy_summary,
-    generate_diverse_states,
-    format_game_context,
-    trace_action_decision,
-    trace_sub_decision,
-    get_sub_decision_options,
-    load_checkpoint_weights,
-    compute_weight_evolution,
-)
-
-sns.set_theme(style="whitegrid", font_scale=0.9)
-policy = LinearPolicy.load({safe_policy_path})
-print(f"Loaded policy: {{policy.weights.shape[0]}} features, {{policy.weights.shape[1]}} actions")""",
-            hidden=True,
-        )
-    )
-
-    # --- Section 1: Weights ---
-    cells.append(
-        _md_cell("""## 1. Action Weights
-
-Each bar shows how strongly a feature pushes toward (positive) or away from (negative) an action.
-Features with large absolute weights are the primary decision drivers.""")
-    )
-
-    cells.append(
-        _code_cell("""actions = list(ACTION_INDEX.keys())
-action_labels = [a.replace("_", " ").title() for a in actions]
-sign_palette = {"pos": "#2c7bb6", "neg": "#d7191c"}
-
-fig, axes = plt.subplots(1, 3, figsize=(16, 8), sharey=True)
-for idx, (action, label) in enumerate(zip(actions, action_labels)):
-    j = ACTION_INDEX[action]
-    weights = [float(policy.weights[i, j]) for i in range(len(FEATURE_NAMES))]
-    colors = [sign_palette["pos"] if w >= 0 else sign_palette["neg"] for w in weights]
-    axes[idx].barh(FEATURE_NAMES, weights, color=colors)
-    axes[idx].set_title(label, fontweight="bold")
-    axes[idx].axvline(x=0, color="gray", linewidth=0.5)
-    if idx > 0:
-        axes[idx].tick_params(labelleft=False)
-axes[0].invert_yaxis()
-fig.suptitle("Action Weights by Feature", fontsize=14, fontweight="bold")
-fig.tight_layout()
-plt.show()""")
-    )
-
-    # --- Section 2: Importance ---
-    cells.append(
-        _md_cell("""## 2. Feature Importance
-
-Overall importance = sum of |weight| across all 3 actions. Features at the top have the most
-influence on action selection regardless of direction.""")
-    )
-
-    cells.append(
-        _code_cell("""importance = compute_feature_importance(policy)
-names, values = zip(*importance)
-
-fig, ax = plt.subplots(figsize=(10, 7))
-ax.barh(list(names), list(values), color="#2c7bb6")
-ax.invert_yaxis()
-ax.set_title("Feature Importance (sum |weight| across actions)", fontweight="bold")
-ax.set_xlabel("Importance")
-fig.tight_layout()
-plt.show()""")
-    )
-
-    # --- Section 3: Strategy rules ---
-    cells.append(
-        _md_cell("""## 3. Strategy Rules
-
-Human-readable rules extracted from significant weight patterns. Each rule describes a condition
-(feature state) and the resulting action preference.""")
-    )
-
-    cells.append(
-        _code_cell("""rules = generate_strategy_rules(policy, threshold=0.3)
-print(format_strategy_summary(rules))""")
-    )
-
-    # --- Section 4: Decision traces ---
-    cells.append(
-        _md_cell("""## 4. Decision Traces
-
-Three representative game states (confident, moderate, uncertain) showing per-feature
-score contributions for each action. This reveals *why* the policy makes each decision.""")
-    )
-
-    cells.append(
-        _code_cell("""samples = generate_diverse_states(policy, num_candidates=200, seed=42)
-
-for si, sample in enumerate(samples):
-    state = sample["state"]
-    entropy = sample["entropy"]
-    label = sample["label"]
-
-    print(f"{'=' * 70}")
-    print(f"  Sample {si + 1}: {label} (entropy: {entropy:.2f})")
-    print(f"{'=' * 70}")
-    print(format_game_context(state))
-
-    breakdowns = trace_action_decision(policy, state)
-    print("\\n  Action Probabilities:")
-    for b in breakdowns:
-        bar = "#" * int(b.probability * 40)
-        print(f"    {b.action_name:<14s}  prob: {b.probability:5.1%}  score: {b.total_score:+.3f}  {bar}")
-        for c in b.contributions[:5]:
-            sign = "+" if c.contribution >= 0 else ""
-            print(f"      {sign}{c.contribution:.3f}  {c.feature_name:>22s}"
-                  f"  (w={c.weight:+.3f} * v={c.feature_value:.3f})")
-        print()
-
-    # Sub-decision for top action
-    top_action = breakdowns[0].action_name
-    options = get_sub_decision_options(state)
-
-    if top_action == "play_a_bird" and options["playable_birds"]:
-        print("  Sub-Decision: Which bird to play?")
-        sub_breakdowns = trace_sub_decision(policy, state, options["playable_birds"])
-        for sb in sub_breakdowns:
-            bar = "#" * int(sb.probability * 30)
-            print(f"    {sb.action_name:<30s}  prob: {sb.probability:5.1%}  {bar}")
-            for c in sb.contributions[:3]:
-                sign = "+" if c.contribution >= 0 else ""
-                print(f"      {sign}{c.contribution:.3f}  {c.feature_name:>26s}")
-            print()
-
-    elif top_action == "draw_a_bird":
-        print("  Sub-Decision: Which bird to draw?")
-        sub_breakdowns = trace_sub_decision(policy, state, options["drawable_options"])
-        for sb in sub_breakdowns:
-            bar = "#" * int(sb.probability * 30)
-            print(f"    {sb.action_name:<30s}  prob: {sb.probability:5.1%}  {bar}")
-            for c in sb.contributions[:3]:
-                sign = "+" if c.contribution >= 0 else ""
-                print(f"      {sign}{c.contribution:.3f}  {c.feature_name:>26s}")
-            print()
-
-    print()""")
-    )
-
-    # --- Section 5: Weight evolution ---
-    cells.append(
-        _md_cell("""## 5. Weight Evolution
-
-How the top features' weights changed over training. Convergence (flat lines) suggests stable
-learning; oscillation may indicate instability or competing gradients.""")
-    )
-
-    cells.append(
-        _code_cell(f"""checkpoint_data = load_checkpoint_weights({safe_models_dir}, max_checkpoints=50)
-iterations = checkpoint_data["iterations"]
-
-if iterations:
-    importance = compute_feature_importance(policy)
-    top_features = [name for name, _ in importance[:5]]
+    sns.set_theme(style="whitegrid", font_scale=0.9)
+    policy = LinearPolicy.load(policy_path)
     actions = list(ACTION_INDEX.keys())
+    sign_palette = {"pos": "#2c7bb6", "neg": "#d7191c"}
 
-    fig, axes = plt.subplots(len(top_features), 1, figsize=(10, 3 * len(top_features)), sharex=True)
-    if len(top_features) == 1:
-        axes = [axes]
+    sections = []
 
-    for idx, fname in enumerate(top_features):
-        ax = axes[idx]
-        for aname in actions:
-            evo = compute_weight_evolution(checkpoint_data, fname, aname)
-            ax.plot(evo["iterations"], evo["values"], label=aname, linewidth=1.5)
-        ax.axhline(y=0, color="gray", linewidth=0.5)
-        ax.set_title(fname, fontweight="bold")
-        ax.set_ylabel("Weight")
-        ax.legend(fontsize=8)
-
-    axes[-1].set_xlabel("Training Iteration")
-    fig.suptitle("Weight Evolution (top 5 features)", fontsize=14, fontweight="bold")
+    # ---- Section 1: Action Weights ----
+    fig, axes = plt.subplots(1, 3, figsize=(16, 8), sharey=True)
+    action_labels = [a.replace("_", " ").title() for a in actions]
+    for idx, (action, label) in enumerate(zip(actions, action_labels)):
+        j = ACTION_INDEX[action]
+        weights = [float(policy.weights[i, j]) for i in range(len(FEATURE_NAMES))]
+        colors = [sign_palette["pos"] if w >= 0 else sign_palette["neg"] for w in weights]
+        axes[idx].barh(FEATURE_NAMES, weights, color=colors)
+        axes[idx].set_title(label, fontweight="bold")
+        axes[idx].axvline(x=0, color="gray", linewidth=0.5)
+        if idx > 0:
+            axes[idx].tick_params(labelleft=False)
+    axes[0].invert_yaxis()
+    fig.suptitle("Action Weights by Feature", fontsize=14, fontweight="bold")
     fig.tight_layout()
-    plt.show()
-else:
-    print(f"No checkpoints found in {models_dir}")""")
+    weights_img = _fig_to_base64(fig)
+
+    sections.append(f"""<h2>1. Action Weights</h2>
+<p>Each bar shows how strongly a feature pushes toward (positive, blue) or away from
+(negative, red) an action. Features with large absolute weights are the primary decision
+drivers for the learned policy.</p>
+<img src="{weights_img}" alt="Action weights" style="width:100%;max-width:1200px">""")
+
+    # ---- Section 2: Feature Importance ----
+    importance = compute_feature_importance(policy)
+    names, values = zip(*importance)
+
+    fig, ax = plt.subplots(figsize=(10, 7))
+    ax.barh(list(names), list(values), color="#2c7bb6")
+    ax.invert_yaxis()
+    ax.set_title("Feature Importance (sum |weight| across actions)", fontweight="bold")
+    ax.set_xlabel("Importance")
+    fig.tight_layout()
+    importance_img = _fig_to_base64(fig)
+
+    top5 = importance[:5]
+    top5_text = ", ".join(f"**{n}** ({v:.2f})" for n, v in top5)
+
+    sections.append(f"""<h2>2. Feature Importance</h2>
+<p>Overall importance is the sum of absolute weights across all three actions. Features at the
+top have the most influence on action selection, regardless of direction.</p>
+<p>The top 5 features are: {top5_text}.</p>
+<img src="{importance_img}" alt="Feature importance" style="width:100%;max-width:800px">""")
+
+    # ---- Section 3: Strategy Rules ----
+    rules = generate_strategy_rules(policy, threshold=0.3)
+
+    if rules:
+        rule_rows = []
+        for i, rule in enumerate(rules, 1):
+            rule_rows.append([str(i), rule.condition, rule.behavior, f"{rule.magnitude:.2f}"])
+        rules_table = _html_table(
+            ["#", "Condition", "Behavior", "Strength"],
+            rule_rows,
+            align=["right", "left", "left", "right"],
+        )
+    else:
+        rules_table = "<p><em>No significant strategy patterns detected.</em></p>"
+
+    sections.append(f"""<h2>3. Strategy Rules</h2>
+<p>Human-readable rules extracted from significant weight patterns. Each rule describes a game
+condition and the resulting action preference the policy has learned. Rules are sorted by
+strength (weight spread between preferred and avoided actions).</p>
+{rules_table}""")
+
+    # ---- Section 4: Decision Traces ----
+    samples = generate_diverse_states(policy, num_candidates=200, seed=42)
+    trace_parts = []
+
+    for si, sample in enumerate(samples):
+        state = sample["state"]
+        entropy = sample["entropy"]
+        label = sample["label"]
+        context = format_game_context(state)
+
+        breakdowns = trace_action_decision(policy, state)
+
+        # Action probability bar chart
+        fig, ax = plt.subplots(figsize=(8, 3))
+        bnames = [b.action_name.replace("_", " ").title() for b in breakdowns]
+        bprobs = [b.probability for b in breakdowns]
+        bcolors = ["#2c7bb6", "#F5A623", "#4CAF50"]
+        ax.barh(bnames, bprobs, color=bcolors[: len(bnames)])
+        ax.set_xlim(0, 1)
+        ax.set_xlabel("Probability")
+        ax.set_title(f"Sample {si + 1}: {label} (entropy: {entropy:.2f})", fontweight="bold")
+        fig.tight_layout()
+        trace_img = _fig_to_base64(fig)
+
+        # Top contributions table
+        top_action = breakdowns[0]
+        contrib_rows = []
+        for c in top_action.contributions[:8]:
+            sign = "+" if c.contribution >= 0 else ""
+            contrib_rows.append(
+                [
+                    c.feature_name,
+                    f"{sign}{c.contribution:.3f}",
+                    f"{c.weight:+.3f}",
+                    f"{c.feature_value:.3f}",
+                ]
+            )
+        contrib_table = _html_table(
+            ["Feature", "Contribution", "Weight", "Value"],
+            contrib_rows,
+            align=["left", "right", "right", "right"],
+        )
+
+        # Sub-decision if applicable
+        sub_html = ""
+        options = get_sub_decision_options(state)
+        if top_action.action_name == "play_a_bird" and options["playable_birds"]:
+            sub_breakdowns = trace_sub_decision(policy, state, options["playable_birds"])
+            sub_rows = [[sb.action_name, f"{sb.probability:.1%}", f"{sb.total_score:+.3f}"] for sb in sub_breakdowns]
+            sub_html = "<h4>Sub-decision: which bird to play?</h4>" + _html_table(
+                ["Bird", "Probability", "Score"], sub_rows, align=["left", "right", "right"]
+            )
+        elif top_action.action_name == "draw_a_bird":
+            sub_breakdowns = trace_sub_decision(policy, state, options["drawable_options"])
+            sub_rows = [[sb.action_name, f"{sb.probability:.1%}", f"{sb.total_score:+.3f}"] for sb in sub_breakdowns]
+            sub_html = "<h4>Sub-decision: which bird to draw?</h4>" + _html_table(
+                ["Option", "Probability", "Score"], sub_rows, align=["left", "right", "right"]
+            )
+
+        trace_parts.append(f"""<div class="trace-block">
+<img src="{trace_img}" alt="Trace {si + 1}" style="width:100%;max-width:700px">
+<pre class="game-context">{context}</pre>
+<p>Top action: <strong>{top_action.action_name}</strong> ({top_action.probability:.1%}).
+Top feature contributions:</p>
+{contrib_table}
+{sub_html}
+</div>""")
+
+    sections.append(
+        """<h2>4. Decision Traces</h2>
+<p>Three representative game states spanning confident, moderate, and uncertain decisions.
+For each state, the chart shows the action probability distribution, followed by the game
+context and the feature contributions driving the top action.</p>"""
+        + "\n".join(trace_parts)
     )
 
-    # --- Section 6: Interactive exploration ---
-    cells.append(
-        _md_cell("""## 6. Interactive Exploration
+    # ---- Section 5: Weight Evolution ----
+    checkpoint_data = load_checkpoint_weights(models_dir, max_checkpoints=50)
+    iterations = checkpoint_data["iterations"]
 
-Use the cells below to dig deeper. Modify parameters or add new cells to investigate
-specific questions about the policy.
+    if iterations:
+        top_features = [name for name, _ in importance[:5]]
 
-### What-if: Tweak a feature and see how action probabilities shift""")
-    )
+        fig, axes_evo = plt.subplots(len(top_features), 1, figsize=(10, 3 * len(top_features)), sharex=True)
+        if len(top_features) == 1:
+            axes_evo = [axes_evo]
 
-    cells.append(
-        _code_cell("""from src.rl.featurizer import featurize
-from src.rl.linear_policy import _softmax
+        for idx, fname in enumerate(top_features):
+            ax = axes_evo[idx]
+            for aname in actions:
+                evo = compute_weight_evolution(checkpoint_data, fname, aname)
+                ax.plot(evo["iterations"], evo["values"], label=aname, linewidth=1.5)
+            ax.axhline(y=0, color="gray", linewidth=0.5)
+            ax.set_title(fname, fontweight="bold")
+            ax.set_ylabel("Weight")
+            ax.legend(fontsize=8)
 
-# Pick a sample state and a feature to vary
-sample_state = samples[min(1, len(samples) - 1)]["state"]
-feature_to_vary = "food_supply"  # change this to explore other features
-feature_idx = FEATURE_NAMES.index(feature_to_vary)
+        axes_evo[-1].set_xlabel("Training Iteration")
+        fig.suptitle("Weight Evolution (top 5 features)", fontsize=14, fontweight="bold")
+        fig.tight_layout()
+        evo_img = _fig_to_base64(fig)
 
-base_features = featurize(sample_state)
-sweep_values = np.linspace(0, 1, 20)
+        evo_narrative = (
+            f"Training ran for {iterations[-1]:,} iterations. "
+            f"The chart below shows how the weights for the five most important features "
+            f"evolved during training. Converging lines suggest stable learning; oscillation "
+            f"may indicate competing gradients or noisy reward signals."
+        )
 
-action_names = list(ACTION_INDEX.keys())
-prob_curves = {a: [] for a in action_names}
+        sections.append(f"""<h2>5. Weight Evolution</h2>
+<p>{evo_narrative}</p>
+<img src="{evo_img}" alt="Weight evolution" style="width:100%;max-width:900px">""")
+    else:
+        sections.append("""<h2>5. Weight Evolution</h2>
+<p><em>No checkpoints found. Run training with <code>--save_every</code> to enable
+evolution analysis.</em></p>""")
 
-for val in sweep_values:
-    modified = base_features.copy()
-    modified[feature_idx] = val
-    logits = modified @ policy.weights
-    probs = _softmax(logits)
-    for a in action_names:
-        prob_curves[a].append(probs[ACTION_INDEX[a]])
+    # ---- Section 6: Sub-Decision Weights ----
+    n_state = len(FEATURE_NAMES)
+    option_weights = [
+        (OPTION_FEATURE_NAMES[i], float(policy.sub_weights[n_state + i])) for i in range(len(OPTION_FEATURE_NAMES))
+    ]
+    option_weights.sort(key=lambda x: abs(x[1]), reverse=True)
 
-fig, ax = plt.subplots(figsize=(8, 5))
-for a in action_names:
-    ax.plot(sweep_values, prob_curves[a], label=a.replace("_", " ").title(), linewidth=2)
-ax.axvline(x=float(base_features[feature_idx]), color="gray", linestyle="--", alpha=0.5, label="Current value")
-ax.set_xlabel(f"{feature_to_vary} (normalized)")
-ax.set_ylabel("Action Probability")
-ax.set_title(f"What-if: Varying {feature_to_vary}", fontweight="bold")
-ax.legend()
-ax.set_ylim(0, 1)
-fig.tight_layout()
-plt.show()""")
-    )
+    sub_rows = [[name, f"{w:+.4f}"] for name, w in option_weights]
+    sub_table = _html_table(["Feature", "Weight"], sub_rows, align=["left", "right"])
 
-    cells.append(
-        _md_cell("""### Counterintuitive decisions
+    sections.append(f"""<h2>6. Sub-Decision Weights</h2>
+<p>When the policy decides <em>which</em> bird to play or draw, these per-option feature
+weights determine the selection. Positive weights favor birds with that attribute;
+negative weights avoid them.</p>
+{sub_table}""")
 
-Find states where the policy's top action seems surprising.""")
-    )
+    # ---- Assemble HTML ----
+    body = "\n".join(sections)
+    n_features = policy.weights.shape[0]
+    n_actions = policy.weights.shape[1]
 
-    cells.append(
-        _code_cell("""# Find states where policy gains food despite having a playable bird
-from src.rl.featurizer import featurize as _feat
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Policy Analysis Report</title>
+<style>
+  body {{
+    max-width: 900px;
+    margin: 2em auto;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    color: #24292e;
+    line-height: 1.6;
+    padding: 0 1em;
+  }}
+  h1 {{ border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; }}
+  h2 {{ border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; margin-top: 2em; }}
+  img {{ display: block; margin: 1em 0; }}
+  .report-table {{
+    border-collapse: collapse;
+    margin: 1em 0;
+    font-size: 0.9em;
+    width: 100%;
+  }}
+  .report-table th, .report-table td {{
+    border: 1px solid #dfe2e5;
+    padding: 6px 12px;
+  }}
+  .report-table th {{
+    background-color: #f6f8fa;
+    font-weight: 600;
+  }}
+  .report-table tr:nth-child(even) {{
+    background-color: #f6f8fa;
+  }}
+  .trace-block {{
+    border: 1px solid #e1e4e8;
+    border-radius: 6px;
+    padding: 1em;
+    margin: 1.5em 0;
+    background: #fafbfc;
+  }}
+  .game-context {{
+    background: #f6f8fa;
+    border: 1px solid #e1e4e8;
+    border-radius: 4px;
+    padding: 0.8em;
+    font-size: 0.85em;
+    overflow-x: auto;
+  }}
+  .meta {{ color: #586069; font-size: 0.9em; }}
+</style>
+</head>
+<body>
+<h1>Policy Analysis Report</h1>
+<p class="meta">
+  Generated from <code>{os.path.basename(policy_path)}</code> &mdash;
+  {n_features} features, {n_actions} actions &mdash;
+  {date.today().isoformat()}
+</p>
 
-surprises = []
-for i in range(200):
-    import random
-    random.seed(i + 1000)
-    np.random.seed(i + 1000)
+{body}
 
-    import contextlib, io
-    from src.game import WingspanGame
-    with contextlib.redirect_stdout(io.StringIO()):
-        game = WingspanGame(num_players=2, num_human=0, num_turns=10)
-        turns = (i * 20) // 200
-        for _ in range(turns):
-            if game.game_state.is_game_over():
-                break
-            p = game.game_state.get_current_player()
-            a = p.request_action(game_state=game.game_state)
-            p.take_action(action=a, game_state=game.game_state)
-            game.game_state.end_player_turn(player=p)
-
-    if game.game_state.is_game_over():
-        continue
-
-    features = _feat(game.game_state)
-    can_play = features[FEATURE_NAMES.index("can_play_bird")]
-    logits = features @ policy.weights
-    probs = _softmax(logits)
-    top_action = list(ACTION_INDEX.keys())[np.argmax(probs)]
-
-    if can_play == 1.0 and top_action != "play_a_bird":
-        surprises.append({
-            "state": game.game_state,
-            "top_action": top_action,
-            "probs": {a: float(probs[j]) for a, j in ACTION_INDEX.items()},
-            "turn": game.game_state.game_turn,
-        })
-
-print(f"Found {len(surprises)} states where policy skips a playable bird\\n")
-for s in surprises[:3]:
-    print(f"Turn {s['turn']}: chooses {s['top_action']}")
-    for a, p in s["probs"].items():
-        print(f"  {a:<14s} {p:.1%}")
-    print(format_game_context(s["state"]))
-    print()""")
-    )
-
-    # --- Build notebook ---
-    notebook = {
-        "nbformat": 4,
-        "nbformat_minor": 5,
-        "metadata": {
-            "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
-            "language_info": {"name": "python", "version": "3.12.0"},
-        },
-        "cells": cells,
-    }
+<hr>
+<p class="meta">Generated by <code>python -m src.train report</code></p>
+</body>
+</html>"""
 
     with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(notebook, f, indent=1)
+        f.write(html)
 
     return output_path

--- a/tests/rl/test_report.py
+++ b/tests/rl/test_report.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 import unittest
@@ -14,51 +13,46 @@ class TestGenerateReport(unittest.TestCase):
         policy = LinearPolicy()
         policy.save(self.policy_path)
 
-    def test_generates_valid_notebook(self):
-        output = os.path.join(self.tmpdir, "report.ipynb")
+    def test_generates_html_report(self):
+        output = os.path.join(self.tmpdir, "report.html")
         result = generate_report(self.policy_path, output_path=output, models_dir=self.tmpdir)
         self.assertEqual(result, output)
         self.assertTrue(os.path.isfile(output))
 
         with open(output, encoding="utf-8") as f:
-            nb = json.load(f)
+            content = f.read()
 
-        self.assertEqual(nb["nbformat"], 4)
-        self.assertIn("cells", nb)
-        self.assertIn("metadata", nb)
-        self.assertEqual(len(nb["cells"]), 16)
+        self.assertIn("<!DOCTYPE html>", content)
+        self.assertIn("Policy Analysis Report", content)
+        self.assertIn("Action Weights", content)
+        self.assertIn("Feature Importance", content)
+        self.assertIn("Strategy Rules", content)
+        self.assertIn("Decision Traces", content)
 
-    def test_cell_types(self):
-        output = os.path.join(self.tmpdir, "report.ipynb")
+    def test_contains_embedded_images(self):
+        output = os.path.join(self.tmpdir, "report.html")
         generate_report(self.policy_path, output_path=output, models_dir=self.tmpdir)
 
         with open(output, encoding="utf-8") as f:
-            nb = json.load(f)
+            content = f.read()
 
-        types = [c["cell_type"] for c in nb["cells"]]
-        self.assertIn("markdown", types)
-        self.assertIn("code", types)
-        for cell in nb["cells"]:
-            self.assertIn(cell["cell_type"], ("markdown", "code"))
+        # Charts are embedded as base64 PNGs
+        self.assertIn("data:image/png;base64,", content)
 
     def test_missing_policy_raises(self):
         with self.assertRaises(FileNotFoundError):
             generate_report("/nonexistent/policy.npz")
 
     def test_creates_output_directory(self):
-        output = os.path.join(self.tmpdir, "subdir", "report.ipynb")
+        output = os.path.join(self.tmpdir, "subdir", "report.html")
         generate_report(self.policy_path, output_path=output, models_dir=self.tmpdir)
         self.assertTrue(os.path.isfile(output))
 
-    def test_paths_safely_escaped(self):
-        output = os.path.join(self.tmpdir, "report.ipynb")
-        generate_report(self.policy_path, output_path=output, models_dir=self.tmpdir)
-
-        with open(output, encoding="utf-8") as f:
-            content = f.read()
-
-        # Policy path should appear as a repr'd string, not raw interpolation
-        self.assertIn(repr(self.policy_path), content)
+    def test_default_output_path(self):
+        result = generate_report(self.policy_path, models_dir=self.tmpdir)
+        expected = os.path.join(self.tmpdir, "policy_report.html")
+        self.assertEqual(result, expected)
+        self.assertTrue(os.path.isfile(expected))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Rewrite `train.py report` to generate a self-contained HTML document (not a Jupyter notebook), matching the style of our .Rmd analyses: hidden code, narrative prose, embedded base64 charts, styled tables
- Save v3 baseline (26 features, 84.7% win rate, 20k iterations) and add to model changelog
- Fix `load_checkpoint_weights` to skip checkpoints with mismatched feature dimensions

## v3 Results

| Metric | v2 (22 feat) | v3 (26 feat) | Delta |
|--------|-------------|-------------|-------|
| Win rate | 83.6% | 84.7% | +1.1% |
| Mean score | 13.8 | 14.0 | +0.2 |
| Score diff | +5.4 | +5.6 | +0.2 |

New interaction features ranked #1 (urgency), #5 (endgame_flag), and #8 (vp_at_stake) by importance.

## Test plan
- [x] 5 report tests updated for HTML output
- [x] All 278 tests pass
- [x] Generated report opens correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)