### PR TITLE
Add Claude Code review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,17 @@ on:
 
 jobs:
   claude-review:
+    # This repo is public, unlike the other repos this recipe has shipped on
+    # so far (all private). A bare `pull_request` trigger runs for a PR from
+    # any fork, and this job's `bypassPermissions` claude_args plus the
+    # account-scoped OAuth token below would then be reachable from untrusted
+    # PR content. Restrict to OWNER/MEMBER/COLLABORATOR, the same guard
+    # already on claude.yml, so the risk-acceptance rationale further down
+    # (a trusted-author-only threat model) is actually true here. GitHub
+    # already withholds secrets from fork pull_request runs by default, so
+    # this is defense in depth on top of that platform behavior, not the
+    # only thing standing between a fork PR and the token.
+    if: contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -51,10 +62,12 @@ jobs:
           # process's environment; bypassPermissions gives the agent unapproved
           # Bash over PR content it's instructed to read, so a prompt injection
           # in a reviewed PR could attempt to read that token out of the
-          # environment. Accepted here as a single-author repo where a malicious
-          # PR would have to come from Keith's own content; this is the same
-          # tradeoff every repo on this recipe carries, not one unique to this
-          # file.
+          # environment. Accepted here on the strength of the job-level
+          # author_association guard above: this repo is public, so without
+          # that guard a malicious PR could come from any fork, not just
+          # Keith's own content. Every other repo on this recipe so far is
+          # private, where the same acceptance holds without needing the
+          # guard.
           claude_args: '--permission-mode bypassPermissions'
           # A review that finds nothing still has to say so: silence is otherwise
           # indistinguishable from a broken pipeline.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,63 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # write, not the installer's default of read: without it the review runs to
+      # completion, fails to post, and still reports a green check.
+      pull-requests: write
+      issues: read
+      # id-token deliberately NOT granted. The explicit github_token below makes
+      # the action skip setupGitHubToken's OIDC exchange entirely, so no OIDC
+      # grant is needed here at all.
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        env:
+          # The plugin's review runs inside a Task subagent. Recent CLI versions
+          # start those in the background, and in headless CI the action ends its
+          # turn waiting, never collects the subagent, and posts nothing while
+          # still reporting success. Force foreground.
+          CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1'
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Explicit token so the action skips the OIDC exchange entirely; see the
+          # id-token note in permissions above.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          # --comment is what makes the plugin post. Without it the review runs,
+          # produces findings, logs that no comment will be posted, and leaves the
+          # PR surface empty.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # The plugin's subagents compose novel shell chains and call the
+          # inline-comment MCP tool, so a prefix allowlist rejects each new shape
+          # and was abandoned twice before on other repos. The job's GitHub token
+          # is narrow (repo read plus PR comment, no id-token above), but
+          # claude_code_oauth_token above is account-scoped and reaches this
+          # process's environment; bypassPermissions gives the agent unapproved
+          # Bash over PR content it's instructed to read, so a prompt injection
+          # in a reviewed PR could attempt to read that token out of the
+          # environment. Accepted here as a single-author repo where a malicious
+          # PR would have to come from Keith's own content; this is the same
+          # tradeoff every repo on this recipe carries, not one unique to this
+          # file.
+          claude_args: '--permission-mode bypassPermissions'
+          # A review that finds nothing still has to say so: silence is otherwise
+          # indistinguishable from a broken pipeline.
+          use_sticky_comment: true
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,84 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Trusted-association guard, not just an '@claude' substring test. The
+    # installer-default guard (`contains(body, '@claude')`) has no awareness of
+    # code spans: on wildlife-sanctuary#64 a Copilot review body that merely
+    # *discussed* the tag flow, with '@claude' inside a code span, tripped tag
+    # mode, and the run then failed because Copilot is a bot with no author
+    # association. This repo requests a Copilot review on every PR
+    # (`--reviewer copilot-pull-request-reviewer`), so the same trip would
+    # recur here on every PR. Restricting to OWNER/MEMBER/COLLABORATOR (the
+    # pattern proven on pricing_clusters_prod and personal-config-backup)
+    # fixes it while keeping real @claude mentions in PR reviews working.
+    if: |
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body || '', '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+    runs-on: ubuntu-latest
+    permissions:
+      # contents stays read on purpose. Tag mode also branches and commits, so a
+      # request to @claude for a code change will 403 rather than open a PR.
+      contents: read
+      pull-requests: write
+      # write, not the installer's default of read: the explicit github_token
+      # below is scoped by this block rather than by the OIDC-exchanged app
+      # token it replaces, and that token carried issues:write by default. This
+      # workflow sets no prompt, so an issues-triggered run enters tag mode and
+      # posts its first comment via issues.createComment before doing anything
+      # else; under issues: read that call 403s on every @claude mention.
+      # claude-code-review.yml never calls issues.createComment and keeps
+      # issues: read even with the explicit token.
+      issues: write
+      actions: read # Required for Claude to read CI results on PRs
+      # id-token deliberately NOT granted. The explicit github_token below
+      # means setupGitHubToken never falls through to the OIDC exchange that
+      # would otherwise need it.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1'
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Explicit token so the action skips the OIDC exchange entirely; see
+          # the id-token note in permissions above.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'


### PR DESCRIPTION
Refs #257 (keithgw/personal-config-backup)

Lands `claude.yml` (tag mode) and `claude-code-review.yml` (PR review) per the current recipe in `pr-and-ci-setup.md`, including the settled `author_association` guard on `claude.yml` from the start (avoids the `@claude`-in-code-span trip a Copilot review body can cause).

The explicit `github_token` on both workflows bypasses branch validation, so this workflow-edit PR should review itself.

Acceptance criteria (wingspan slice of #257):
- [ ] `CLAUDE_CODE_OAUTH_TOKEN` set as a repository secret (done pre-PR)
- [ ] Workflows landed, configured to the recipe (this PR)
- [ ] A visible Claude review comment observed on this PR (pending CI)
- [ ] `claude` check green, or its failure explicitly accepted with reasoning (pending CI)
